### PR TITLE
Use trigger first in ordinal

### DIFF
--- a/lua/telescope/_extensions/luasnip.lua
+++ b/lua/telescope/_extensions/luasnip.lua
@@ -104,9 +104,9 @@ local luasnip_fn = function(opts)
                     value = entry,
                     display = make_display,
 
-                    ordinal = entry.ft .. " " ..
-                              filter_null(entry.context.trigger) .. " " ..
+                    ordinal = filter_null(entry.context.trigger) .. " " ..
                               filter_null(entry.context.name) .. " " ..
+                              entry.ft .. " " ..
                               filter_description(entry.context.name, entry.context.description),
 
                     preview_command = function(pvw_entry, bufnr)


### PR DESCRIPTION
I noticed that when a description contained the trigger for a different
snippet, the snippet with the description would be sorted before the
snippet with the matching trigger.

**before:**

![before](https://user-images.githubusercontent.com/2452038/139533672-429483e8-fdb1-48eb-9027-2ae6b8356ca2.png)

**after:**

![after](https://user-images.githubusercontent.com/2452038/139533671-eee210ea-f6a7-4e43-ac0b-bcbb9aad2804.png)