### PR TITLE
FIX: error when hitting <c-q> to send content to quickfix windows in Telescope picker

### DIFF
--- a/lua/telescope/_extensions/luasnip.lua
+++ b/lua/telescope/_extensions/luasnip.lua
@@ -130,6 +130,7 @@ M.luasnip_fn = function(opts)
                     filename = entry.context.trigger,
                     display = make_display,
                     text = string.format(" => %s | %s | %s", entry.ft, entry.context.name, entry.context.description[1] or ''),
+                    ordinal = search_fn(entry),
                     preview_command = function(_, bufnr)
                         local snippet = get_docstring(luasnip, entry.ft, entry.context)
                         if opts.preview.check_mime_type then

--- a/lua/telescope/_extensions/luasnip.lua
+++ b/lua/telescope/_extensions/luasnip.lua
@@ -127,8 +127,9 @@ M.luasnip_fn = function(opts)
                     or default_search_text
                 return {
                     value = entry,
+                    filename = entry.context.trigger,
                     display = make_display,
-                    ordinal = search_fn(entry),
+                    text = string.format(" => %s | %s | %s", entry.ft, entry.context.name, entry.context.description[1] or ''),
                     preview_command = function(_, bufnr)
                         local snippet = get_docstring(luasnip, entry.ft, entry.context)
                         if opts.preview.check_mime_type then

--- a/lua/telescope/_extensions/luasnip.lua
+++ b/lua/telescope/_extensions/luasnip.lua
@@ -129,7 +129,7 @@ M.luasnip_fn = function(opts)
                     value = entry,
                     filename = entry.context.trigger,
                     display = make_display,
-                    text = string.format(" => %s | %s | %s", entry.ft, entry.context.name, entry.context.description[1] or ''),
+                    text = string.format(" %s | %s | %s", entry.ft, entry.context.name, entry.context.description[1] or ''),
                     ordinal = search_fn(entry),
                     preview_command = function(_, bufnr)
                         local snippet = get_docstring(luasnip, entry.ft, entry.context)


### PR DESCRIPTION
This PR is for @pdckxd 's quick-fix window fix. I merged this change earlier, and things regressed, so I'm reopening as draft to investigate.

Tracked as issue #29 .